### PR TITLE
update Footer component to display group members

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,7 +1,10 @@
 const Footer = () => {
   return (
     <footer className="w-full text-center py-4 bg-[#C8102E] text-white">
-      <p className="m-0 text-sm">@CopyWrong 2026 - Team Hortons</p>
+      <p className="m-0 text-l">@CopyWrong 2026 - Team Hortons</p>
+      <div className="mt-2 text-s">
+        Group Members: Fan Luo, Yunfei Wu, Justin Xia
+      </div>
     </footer>
   );
 };


### PR DESCRIPTION
This pull request makes a minor update to the `Footer` component, improving the display of group member information and adjusting text sizing.

- Updated the copyright text size from `text-sm` to `text-l` and added a new line listing the group members in the footer 