### PR TITLE
Yunfei Sprint 5: save orders by signed-in user session

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -28,6 +28,7 @@ model MenuReview {
 
 model Order {
   id           Int         @id @default(autoincrement())
+  userId       String?
   customerName String
   pickupNotes  String
   createdAt    DateTime    @default(now())

--- a/backend/src/controllers/orderController.ts
+++ b/backend/src/controllers/orderController.ts
@@ -1,10 +1,20 @@
 import { Request, Response } from "express";
+import { RequireAuthProp } from "@clerk/clerk-sdk-node";
 import { orderService } from "../services/orderService.js";
 
 export const orderController = {
   async getCurrentOrder(req: Request, res: Response) {
     try {
-      const currentOrder = await orderService.getCurrentOrder();
+      const authRequest = req as RequireAuthProp<Request>;
+      const userId = authRequest.auth.userId;
+
+      if (!userId) {
+        return res.status(401).json({
+          error: "Unauthorized",
+        });
+      }
+
+      const currentOrder = await orderService.getCurrentOrder(userId);
 
       if (!currentOrder) {
         return res.json({
@@ -29,9 +39,18 @@ export const orderController = {
 
   async saveCurrentOrder(req: Request, res: Response) {
     try {
+      const authRequest = req as RequireAuthProp<Request>;
+      const userId = authRequest.auth.userId;
+
+      if (!userId) {
+        return res.status(401).json({
+          error: "Unauthorized",
+        });
+      }
+
       const { customerName, pickupNotes, items } = req.body;
 
-      const savedOrder = await orderService.saveCurrentOrder({
+      const savedOrder = await orderService.saveCurrentOrder(userId, {
         customerName: typeof customerName === "string" ? customerName : "",
         pickupNotes: typeof pickupNotes === "string" ? pickupNotes : "",
         items: Array.isArray(items) ? items : [],

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,10 +1,11 @@
+import 'dotenv/config';
+
 import express from "express";
 import cors from "cors";
 import menuRoutes from "./routes/menuRoutes.js";
 import orderRoutes from "./routes/orderRoutes.js";
 import communityPostRoutes from "./routes/communityPostRoutes.js";
 
-import 'dotenv/config';
 const app = express();
 const PORT = process.env.PORT || 3000;
 

--- a/backend/src/routes/orderRoutes.ts
+++ b/backend/src/routes/orderRoutes.ts
@@ -1,10 +1,16 @@
 import { Router } from "express";
+import { ClerkExpressRequireAuth } from "@clerk/clerk-sdk-node";
 import { orderController } from "../controllers/orderController.js";
 import { validateCurrentOrder } from "../middleware/validateCurrentOrder.js";
 
 const router = Router();
 
-router.get("/current", orderController.getCurrentOrder);
-router.put("/current", validateCurrentOrder, orderController.saveCurrentOrder);
+router.get("/current", ClerkExpressRequireAuth(), orderController.getCurrentOrder);
+router.put(
+  "/current",
+  ClerkExpressRequireAuth(),
+  validateCurrentOrder,
+  orderController.saveCurrentOrder
+);
 
 export default router;

--- a/backend/src/services/orderService.ts
+++ b/backend/src/services/orderService.ts
@@ -11,8 +11,11 @@ type SaveCurrentOrderInput = {
 };
 
 export const orderService = {
-  async getCurrentOrder() {
+  async getCurrentOrder(userId: string) {
     const existingOrder = await prisma.order.findFirst({
+      where: {
+        userId,
+      },
       orderBy: {
         updatedAt: "desc",
       },
@@ -24,8 +27,11 @@ export const orderService = {
     return existingOrder;
   },
 
-  async saveCurrentOrder(data: SaveCurrentOrderInput) {
+  async saveCurrentOrder(userId: string, data: SaveCurrentOrderInput) {
     const existingOrder = await prisma.order.findFirst({
+      where: {
+        userId,
+      },
       orderBy: {
         updatedAt: "desc",
       },
@@ -37,6 +43,7 @@ export const orderService = {
     if (!existingOrder) {
       const createdOrder = await prisma.order.create({
         data: {
+          userId,
           customerName: data.customerName,
           pickupNotes: data.pickupNotes,
           items: {

--- a/frontend/src/components/pages/OrdersPage.tsx
+++ b/frontend/src/components/pages/OrdersPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import { SignedIn, SignedOut, SignInButton, useAuth } from "@clerk/clerk-react";
 import type { CurrentOrder, OrderItem } from "../orders/types/order";
 import { OrderItemRow } from "../orders/OrderItemRow";
 import { useMenuItems } from "../../hooks/useMenuItems";
@@ -6,12 +7,13 @@ import { orderRepository } from "../../repositories/orderRepository";
 
 export function OrdersPage() {
   const { filteredItems, isLoading, error } = useMenuItems();
+  const { getToken, isSignedIn, isLoaded } = useAuth();
 
   const [customerName, setCustomerName] = useState<string>("");
   const [pickupNotes, setPickupNotes] = useState<string>("");
   const [orderItems, setOrderItems] = useState<OrderItem[]>([]);
 
-  const [isOrderLoading, setIsOrderLoading] = useState<boolean>(true);
+  const [isOrderLoading, setIsOrderLoading] = useState<boolean>(false);
   const [orderError, setOrderError] = useState<string | null>(null);
 
   const hasLoadedOrder = useRef(false);
@@ -27,17 +29,35 @@ export function OrdersPage() {
 
   useEffect(() => {
     async function loadCurrentOrder() {
+      if (!isLoaded) {
+        return;
+      }
+
+      if (!isSignedIn) {
+        hasLoadedOrder.current = true;
+        setIsOrderLoading(false);
+        setOrderError(null);
+        return;
+      }
+
       try {
         setIsOrderLoading(true);
         setOrderError(null);
 
-        const currentOrder = await orderRepository.getCurrent();
+        const token = await getToken();
+
+        if (!token) {
+          setOrderError("Failed to load your saved order.");
+          return;
+        }
+
+        const currentOrder = await orderRepository.getCurrent(token);
 
         setCustomerName(currentOrder.customerName);
         setPickupNotes(currentOrder.pickupNotes);
         setOrderItems(currentOrder.items);
       } catch {
-        setOrderError("Failed to load current order.");
+        setOrderError("Failed to load your saved order.");
       } finally {
         setIsOrderLoading(false);
         hasLoadedOrder.current = true;
@@ -45,10 +65,10 @@ export function OrdersPage() {
     }
 
     void loadCurrentOrder();
-  }, []);
+  }, [getToken, isSignedIn, isLoaded]);
 
   useEffect(() => {
-    if (!hasLoadedOrder.current) {
+    if (!isLoaded || !hasLoadedOrder.current || !isSignedIn) {
       return;
     }
 
@@ -60,15 +80,22 @@ export function OrdersPage() {
       };
 
       try {
-        await orderRepository.saveCurrent(currentOrder);
+        const token = await getToken();
+
+        if (!token) {
+          setOrderError("Failed to save your order.");
+          return;
+        }
+
+        await orderRepository.saveCurrent(token, currentOrder);
         setOrderError(null);
       } catch {
-        setOrderError("Failed to save current order.");
+        setOrderError("Failed to save your order.");
       }
     }
 
     void saveCurrentOrder();
-  }, [customerName, pickupNotes, orderItems]);
+  }, [customerName, pickupNotes, orderItems, getToken, isSignedIn, isLoaded]);
 
   const handleAddMenuItem = (item: { id: number; name: string; price: number }) => {
     setOrderItems((oldItems) => {
@@ -87,7 +114,6 @@ export function OrdersPage() {
     setOrderItems((oldItems) => oldItems.filter((item) => item.id !== id));
   };
 
-  // NEW: Function to clear all items
   const handleRemoveAllItems = () => {
     setOrderItems([]);
   };
@@ -97,8 +123,32 @@ export function OrdersPage() {
       <h1 className="text-2xl font-extrabold">Orders</h1>
       <p className="mt-2 text-black/70">What would you like today?</p>
 
+      <div className="mt-4 rounded border border-black/10 bg-[#F7F3E9] p-4">
+        <SignedIn>
+          <p className="text-sm text-black/70">
+            Your order is saved to your signed-in account.
+          </p>
+        </SignedIn>
+
+        <SignedOut>
+          <p className="text-sm text-black/70">
+            You can build an order as a guest, but you need to sign in to save it.
+          </p>
+          <div className="mt-3">
+            <SignInButton mode="modal">
+              <button
+                type="button"
+                className="rounded bg-[#C8102E] px-4 py-2 text-sm font-semibold text-white hover:bg-[#a50d25]"
+              >
+                Sign in to save your order
+              </button>
+            </SignInButton>
+          </div>
+        </SignedOut>
+      </div>
+
       {isOrderLoading ? (
-        <p className="mt-6 text-sm text-black/60">Loading current order...</p>
+        <p className="mt-6 text-sm text-black/60">Loading your saved order...</p>
       ) : null}
 
       {orderError ? (
@@ -107,7 +157,6 @@ export function OrdersPage() {
 
       <div className="mt-8 grid gap-8 md:grid-cols-2">
         <section className="rounded bg-white p-5 shadow">
-          {/* ... Customer Info section remains exactly the same ... */}
           <h2 className="text-lg font-bold">Customer Info</h2>
 
           <div className="mt-4 space-y-4">
@@ -154,10 +203,9 @@ export function OrdersPage() {
         </section>
 
         <section className="rounded bg-white p-5 shadow">
-          {/* UPDATED: Order Items Header with Delete All Button */}
           <div className="flex items-center justify-between">
             <h2 className="text-lg font-bold">Order Items</h2>
-            {orderItems.length > 0 && (
+            {orderItems.length > 0 ? (
               <button
                 type="button"
                 onClick={handleRemoveAllItems}
@@ -165,7 +213,7 @@ export function OrdersPage() {
               >
                 Delete All
               </button>
-            )}
+            ) : null}
           </div>
 
           <div className="mt-4 flex flex-wrap gap-2">
@@ -194,7 +242,6 @@ export function OrdersPage() {
           </div>
 
           <ul className="mt-5 space-y-3">
-            {/* UPDATED: Slice array to only render the first 5 items */}
             {orderItems.slice(0, 5).map((item) => (
               <OrderItemRow
                 key={item.id}
@@ -204,12 +251,12 @@ export function OrdersPage() {
             ))}
           </ul>
 
-          {/* NEW: Display message if there are more than 5 items */}
-          {orderItems.length > 5 && (
+          {orderItems.length > 5 ? (
             <p className="mt-3 text-sm font-medium italic text-black/60">
-              ...and {orderItems.length - 5} more item{orderItems.length - 5 !== 1 ? 's' : ''} in your order.
+              ...and {orderItems.length - 5} more item
+              {orderItems.length - 5 !== 1 ? "s" : ""} in your order.
             </p>
-          )}
+          ) : null}
 
           {orderItems.length === 0 ? (
             <p className="mt-4 text-sm text-black/60">

--- a/frontend/src/repositories/orderRepository.ts
+++ b/frontend/src/repositories/orderRepository.ts
@@ -5,8 +5,12 @@ const API_BASE_URL = import.meta.env.PROD
   : "http://localhost:3000/api/orders";
 
 export const orderRepository = {
-  async getCurrent(): Promise<CurrentOrder> {
-    const response = await fetch(`${API_BASE_URL}/current`);
+  async getCurrent(token: string): Promise<CurrentOrder> {
+    const response = await fetch(`${API_BASE_URL}/current`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
 
     if (!response.ok) {
       throw new Error("Failed to fetch current order");
@@ -21,11 +25,12 @@ export const orderRepository = {
     };
   },
 
-  async saveCurrent(order: CurrentOrder): Promise<CurrentOrder> {
+  async saveCurrent(token: string, order: CurrentOrder): Promise<CurrentOrder> {
     const response = await fetch(`${API_BASE_URL}/current`, {
       method: "PUT",
       headers: {
         "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
       },
       body: JSON.stringify(order),
     });


### PR DESCRIPTION
This PR extends the Orders feature from Sprint 4 to support Sprint 5 user-associated data requirements.

What changed:

* current order data is now saved and loaded by authenticated Clerk user ID on the backend
* the Orders page only loads and saves backend order data for signed-in users
* guest users can still build an order locally, but they are prompted to sign in if they want their order to be saved
* Clerk environment loading was fixed so protected backend order routes can authenticate correctly

How I tested:

* as a guest, I could open Orders, edit fields, add/remove items, and see the sign-in prompt without backend save/load errors
* after signing in, my order loaded correctly and changes were saved
* after refresh, the signed-in order data stayed
* after signing out, the saved signed-in order data no longer appeared in guest mode
